### PR TITLE
Remove reference to removed "InsertBegin" hook

### DIFF
--- a/wakatime.kak
+++ b/wakatime.kak
@@ -162,7 +162,6 @@ def -hidden	wakatime-init %{
 		fi
 		echo "set global wakatime_command '$command'"
 		echo "hook -group WakaTime global InsertKey .* %{ wakatime-heartbeat }"
-		echo "hook -group WakaTime global InsertBegin .* %{ wakatime-heartbeat }"
 		echo "hook -group WakaTime global BufWritePost .* %{ wakatime-heartbeat write }"
 		echo "hook -group WakaTime global BufCreate .* %{ wakatime-heartbeat }"
 		if ! eval "$command $kak_opt_wakatime_options --config-read api_key 2>&1 >/dev/null"; then


### PR DESCRIPTION
This hook was removed in Kakoune 2019.12.10 ([Changelog](https://github.com/mawww/kakoune/blob/90043e7df04359ec9ef629fa46fc6a524673be84/doc/pages/changelog.asciidoc#kakoune-20191210))