### PR TITLE
Check for wakatime-cli command

### DIFF
--- a/wakatime.kak
+++ b/wakatime.kak
@@ -97,6 +97,9 @@ def -hidden	wakatime-init %{
 		if [ -n "$(which wakatime 2> /dev/null)" ]; then
 			# Don't bother downloading it.
 			command="wakatime"
+		elif [ -n "$(which wakatime-cli 2> /dev/null)" ]; then
+			# Don't bother downloading it.
+			command="wakatime-cli"
 		else
 			# We'll try to use a python version
 			# Is Python installed?


### PR DESCRIPTION
The [wakatime-cli docs](https://github.com/wakatime/wakatime-cli/blob/develop/USAGE.md) give the binary's name as `wakatime-cli` instead of `wakatime`. This adds a check for that as a globally-installed binary in addition to the check for `wakatime` so as to avoid a breaking change.